### PR TITLE
feat(rag): add reproducible demo dataset and fingerprint e2e

### DIFF
--- a/agent-lab/backend/src/modules/rag/demo/index.ts
+++ b/agent-lab/backend/src/modules/rag/demo/index.ts
@@ -1,0 +1,103 @@
+import type { AtomicTask } from '../../../core/contracts/task.js'
+
+export type RagDemoDocument = {
+  id: string
+  text: string
+}
+
+export type RagDemoDataset = {
+  id: string
+  name: string
+  documents: RagDemoDocument[]
+}
+
+export type RagDemoConfig = {
+  seed: number
+  embedding: 'mock'
+  dataset: {
+    documents: RagDemoDocument[]
+  }
+  chunking: {
+    strategy: 'doc'
+  }
+  retriever: {
+    type: 'bm25'
+    impl: 'wink'
+    topK: number
+  }
+  generator: {
+    type: 'template'
+  }
+}
+
+export const RAG_DEMO_DATASET: RagDemoDataset = {
+  id: 'rag.demo.v1',
+  name: 'RAG Demo Dataset v1',
+  documents: [
+    {
+      id: 'doc.alpha',
+      text: 'Alpha is the first Greek letter and often marks the beginning of a sequence.'
+    },
+    {
+      id: 'doc.beta',
+      text: 'Beta follows Alpha and is commonly used to label second versions or test releases.'
+    },
+    {
+      id: 'doc.gamma',
+      text: 'Gamma is the third Greek letter and appears in mathematics and physics contexts.'
+    }
+  ]
+}
+
+export const RAG_DEMO_TASK: AtomicTask = {
+  id: 'rag.demo.task.v1',
+  name: 'RAG Demo Retrieval Task',
+  type: 'rag',
+  input: {
+    query: 'What is Alpha?',
+    retrieval: { topK: 1 }
+  },
+  metadata: {
+    tags: ['demo', 'reproducible']
+  }
+}
+
+export function buildRagDemoConfig(
+  overrides: Partial<Omit<RagDemoConfig, 'dataset'>> & {
+    dataset?: Partial<RagDemoConfig['dataset']>
+  } = {}
+): RagDemoConfig {
+  return {
+    seed: overrides.seed ?? 20260208,
+    embedding: 'mock',
+    dataset: {
+      documents: overrides.dataset?.documents ?? RAG_DEMO_DATASET.documents
+    },
+    chunking: {
+      strategy: 'doc'
+    },
+    retriever: {
+      type: 'bm25',
+      impl: 'wink',
+      topK: overrides.retriever?.topK ?? 1
+    },
+    generator: {
+      type: 'template'
+    }
+  }
+}
+
+export function buildRagDemoTask(overrides: Partial<AtomicTask> = {}): AtomicTask {
+  return {
+    ...RAG_DEMO_TASK,
+    ...overrides,
+    input: {
+      ...((RAG_DEMO_TASK.input as Record<string, unknown>) ?? {}),
+      ...((overrides.input as Record<string, unknown>) ?? {})
+    },
+    metadata: {
+      ...((RAG_DEMO_TASK.metadata as Record<string, unknown>) ?? {}),
+      ...((overrides.metadata as Record<string, unknown>) ?? {})
+    }
+  }
+}

--- a/agent-lab/backend/src/modules/rag/demo/rag-demo.e2e.test.ts
+++ b/agent-lab/backend/src/modules/rag/demo/rag-demo.e2e.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { AtomicTask } from '../../../core/contracts/task.js'
+import { EvalEngine } from '../../../core/engine/eval-engine.js'
+import { InMemoryStorage } from '../../../core/engine/storage.js'
+import { EvaluatorRegistry } from '../../../core/registry/evaluator-registry.js'
+import { ReporterRegistry } from '../../../core/registry/reporter-registry.js'
+import { RunnerRegistry } from '../../../core/registry/runner-registry.js'
+import { RagBm25Runner } from '../runners/rag-bm25-runner.js'
+import { RagMetricsEvaluator } from '../evaluators/rag-metrics-evaluator.js'
+import { RagEvidenceReporter } from '../reporters/rag-evidence-reporter.js'
+import {
+  RAG_DEMO_DATASET,
+  buildRagDemoConfig,
+  buildRagDemoTask
+} from './index.js'
+
+describe('RAG demo e2e', () => {
+  let engine: EvalEngine
+
+  beforeEach(() => {
+    const runnerRegistry = new RunnerRegistry()
+    const evaluatorRegistry = new EvaluatorRegistry()
+    const reporterRegistry = new ReporterRegistry()
+
+    runnerRegistry.register(new RagBm25Runner())
+    evaluatorRegistry.register(new RagMetricsEvaluator())
+    reporterRegistry.register(new RagEvidenceReporter())
+
+    engine = new EvalEngine({
+      runnerRegistry,
+      evaluatorRegistry,
+      reporterRegistry,
+      storage: new InMemoryStorage()
+    })
+  })
+
+  it('produces stable fingerprint for same input and default config', async () => {
+    const taskA: AtomicTask = buildRagDemoTask({ id: 'rag-demo-task' })
+    const taskB: AtomicTask = buildRagDemoTask({ id: 'rag-demo-task' })
+
+    const configA = buildRagDemoConfig()
+    const configB = buildRagDemoConfig()
+
+    expect(RAG_DEMO_DATASET.documents.length).toBeGreaterThan(0)
+
+    const first = await engine.evaluateTask(taskA, 'rag.bm25', configA, ['rag.metrics'])
+    const second = await engine.evaluateTask(taskB, 'rag.bm25', configB, ['rag.metrics'])
+
+    expect(first.run.status).toBe('completed')
+    expect(second.run.status).toBe('completed')
+
+    expect(first.run.provenance.configHash).toBeDefined()
+    expect(first.run.provenance.runFingerprint).toBeDefined()
+    expect(first.run.provenance.runFingerprint).toBe(second.run.provenance.runFingerprint)
+    expect(first.run.provenance.configHash).toBe(second.run.provenance.configHash)
+
+    expect(first.run.output).toEqual(second.run.output)
+    expect(first.run.provenance.configSnapshot).toEqual(
+      expect.objectContaining({ runnerId: 'rag.bm25' })
+    )
+    expect(first.scores.some(score => score.metric === 'citation_precision')).toBe(true)
+  })
+})

--- a/agent-lab/backend/src/modules/rag/index.ts
+++ b/agent-lab/backend/src/modules/rag/index.ts
@@ -3,3 +3,5 @@ export { RagMetricsEvaluator } from './evaluators/rag-metrics-evaluator.js'
 export { RagMockRunner } from './runners/rag-mock-runner.js'
 export { RagBm25Runner } from './runners/rag-bm25-runner.js'
 export { RagArtifactSchemas } from './schemas.js'
+
+export * from './demo/index.js'


### PR DESCRIPTION
## Summary
- add reusable RAG demo fixtures (RAG_DEMO_DATASET, RAG_DEMO_TASK) plus buildRagDemoConfig/buildRagDemoTask helpers
- add a focused e2e test that runs the real RAG runner + reporter + evaluator pipeline and asserts stable configHash/runFingerprint
- export demo utilities from the rag module barrel for downstream runtime/API wiring

## Test Plan
- [x] npm test -- src/modules/rag/demo/rag-demo.e2e.test.ts src/modules/rag/runners/rag-bm25-runner.e2e.test.ts --run
