### PR TITLE
feat: align rag backend runtime and registry definitions

### DIFF
--- a/agent-lab/backend/src/api/eval/runtime.test.ts
+++ b/agent-lab/backend/src/api/eval/runtime.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { InMemoryStorage } from '../../core/engine/storage.js'
+import type { AtomicTask } from '../../core/contracts/task.js'
+import { createEvalRuntime } from './runtime.js'
+
+describe('createEvalRuntime', () => {
+  it('registers real rag runner and rag definitions', () => {
+    const runtime = createEvalRuntime({ storage: new InMemoryStorage() })
+
+    expect(runtime.runnerRegistry.get('rag.bm25')).toBeTruthy()
+    expect(runtime.runnerRegistry.get('rag.mock')).toBeNull()
+
+    expect(runtime.taskDefinitionRegistry.list()).toEqual([
+      expect.objectContaining({ id: 'rag.qa', type: 'rag' })
+    ])
+    expect(runtime.workflowDefinitionRegistry.list()).toEqual([
+      expect.objectContaining({ id: 'rag.retrieve-generate' })
+    ])
+    expect(runtime.methodDefinitionRegistry.list()).toEqual([
+      expect.objectContaining({ id: 'rag.bm25.template' })
+    ])
+  })
+
+  it('runs rag pipeline with artifacts, reports, scores and reproducible provenance', async () => {
+    const storage = new InMemoryStorage()
+    const runtime = createEvalRuntime({ storage })
+
+    const task: AtomicTask = {
+      id: 'task-rag-1',
+      name: 'RAG QA',
+      type: 'rag',
+      input: { query: 'Alpha', retrieval: { topK: 1 } },
+      metadata: {}
+    }
+
+    const result = await runtime.engine.evaluateTask(
+      task,
+      'rag.bm25',
+      {
+        dataset: {
+          documents: [
+            { id: 'd1', text: 'Alpha is the first letter.' },
+            { id: 'd2', text: 'Beta is the second letter.' },
+            { id: 'd3', text: 'Gamma is the third letter.' }
+          ]
+        },
+        retriever: { type: 'bm25', impl: 'wink', topK: 1 },
+        generator: { type: 'template' }
+      },
+      ['rag.metrics']
+    )
+
+    expect(result.run.status).toBe('completed')
+    expect(result.run.artifacts?.length ?? 0).toBeGreaterThan(0)
+    expect(result.run.reports?.length ?? 0).toBeGreaterThan(0)
+    expect(result.scores.some(score => score.metric === 'citation_precision')).toBe(true)
+
+    expect(result.run.provenance.configSnapshot).toEqual(
+      expect.objectContaining({
+        task,
+        runnerId: 'rag.bm25'
+      })
+    )
+    expect(result.run.provenance.runFingerprint).toEqual(expect.any(String))
+
+    const savedRun = await storage.getRun(result.run.id)
+    expect(savedRun?.provenance.configSnapshot).toEqual(
+      expect.objectContaining({
+        task,
+        runnerId: 'rag.bm25'
+      })
+    )
+    expect(savedRun?.provenance.runFingerprint).toEqual(expect.any(String))
+  })
+})

--- a/agent-lab/backend/src/api/eval/runtime.ts
+++ b/agent-lab/backend/src/api/eval/runtime.ts
@@ -1,0 +1,103 @@
+import { PrismaClient } from '@prisma/client'
+import { EvalEngine, PrismaStorage } from '../../core/engine/index.js'
+import type { Storage } from '../../core/engine/storage.js'
+import { RunnerRegistry } from '../../core/registry/runner-registry.js'
+import { EvaluatorRegistry } from '../../core/registry/evaluator-registry.js'
+import { ReporterRegistry } from '../../core/registry/reporter-registry.js'
+import {
+  MethodDefinitionRegistry,
+  TaskDefinitionRegistry,
+  WorkflowDefinitionRegistry
+} from '../../core/registry/definition-registry.js'
+import { LLMClient } from '../../lib/llm/client.js'
+import {
+  IntentLLMRunner,
+  IntentMetricsEvaluator,
+  DialogueLLMRunner,
+  DialogueMetricsEvaluator,
+  MemoryLLMRunner,
+  MemoryMetricsEvaluator,
+  RagBm25Runner,
+  RagMetricsEvaluator,
+  RagEvidenceReporter,
+  registerRagDefinitions
+} from '../../modules/index.js'
+
+export interface EvalRuntime {
+  engine: EvalEngine
+  runnerRegistry: RunnerRegistry
+  evaluatorRegistry: EvaluatorRegistry
+  reporterRegistry: ReporterRegistry
+  taskDefinitionRegistry: TaskDefinitionRegistry
+  workflowDefinitionRegistry: WorkflowDefinitionRegistry
+  methodDefinitionRegistry: MethodDefinitionRegistry
+}
+
+export interface CreateEvalRuntimeOptions {
+  prisma?: PrismaClient
+  storage?: Storage
+  llmClient?: LLMClient
+}
+
+const createDefaultLLMClient = (): LLMClient => {
+  return new LLMClient({
+    id: 'default',
+    name: 'Default OpenAI Config',
+    provider: 'openai',
+    apiKey: process.env.OPENAI_API_KEY || '',
+    baseUrl: 'https://api.openai.com/v1',
+    modelName: process.env.LLM_MODEL || 'gpt-4',
+    isDefault: true,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  })
+}
+
+export const createEvalRuntime = (options: CreateEvalRuntimeOptions = {}): EvalRuntime => {
+  const runnerRegistry = new RunnerRegistry()
+  const evaluatorRegistry = new EvaluatorRegistry()
+  const reporterRegistry = new ReporterRegistry()
+  const taskDefinitionRegistry = new TaskDefinitionRegistry()
+  const workflowDefinitionRegistry = new WorkflowDefinitionRegistry()
+  const methodDefinitionRegistry = new MethodDefinitionRegistry()
+
+  const llmClient = options.llmClient ?? createDefaultLLMClient()
+
+  runnerRegistry.register(new IntentLLMRunner(llmClient))
+  runnerRegistry.register(new DialogueLLMRunner(llmClient))
+  runnerRegistry.register(new MemoryLLMRunner(llmClient))
+  runnerRegistry.register(new RagBm25Runner())
+
+  evaluatorRegistry.register(new IntentMetricsEvaluator())
+  evaluatorRegistry.register(new DialogueMetricsEvaluator())
+  evaluatorRegistry.register(new MemoryMetricsEvaluator())
+  evaluatorRegistry.register(new RagMetricsEvaluator())
+
+  reporterRegistry.register(new RagEvidenceReporter())
+
+  registerRagDefinitions(
+    taskDefinitionRegistry,
+    workflowDefinitionRegistry,
+    methodDefinitionRegistry
+  )
+
+  const storage =
+    options.storage ?? new PrismaStorage(options.prisma ?? new PrismaClient())
+
+  const engine = new EvalEngine({
+    runnerRegistry,
+    evaluatorRegistry,
+    reporterRegistry,
+    storage
+  })
+
+  return {
+    engine,
+    runnerRegistry,
+    evaluatorRegistry,
+    reporterRegistry,
+    taskDefinitionRegistry,
+    workflowDefinitionRegistry,
+    methodDefinitionRegistry
+  }
+}

--- a/agent-lab/backend/src/modules/rag/definitions.test.ts
+++ b/agent-lab/backend/src/modules/rag/definitions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MethodDefinitionRegistry,
+  TaskDefinitionRegistry,
+  WorkflowDefinitionRegistry
+} from '../../core/registry/definition-registry.js'
+import { registerRagDefinitions } from './definitions.js'
+
+describe('registerRagDefinitions', () => {
+  it('registers task/workflow/method definitions', () => {
+    const taskRegistry = new TaskDefinitionRegistry()
+    const workflowRegistry = new WorkflowDefinitionRegistry()
+    const methodRegistry = new MethodDefinitionRegistry()
+
+    registerRagDefinitions(taskRegistry, workflowRegistry, methodRegistry)
+
+    expect(taskRegistry.list()).toEqual([
+      expect.objectContaining({ id: 'rag.qa', type: 'rag' })
+    ])
+    expect(workflowRegistry.list()).toEqual([
+      expect.objectContaining({ id: 'rag.retrieve-generate' })
+    ])
+    expect(methodRegistry.list()).toEqual([
+      expect.objectContaining({ id: 'rag.bm25.template' })
+    ])
+  })
+
+  it('throws when registering duplicate definitions', () => {
+    const taskRegistry = new TaskDefinitionRegistry()
+    const workflowRegistry = new WorkflowDefinitionRegistry()
+    const methodRegistry = new MethodDefinitionRegistry()
+
+    registerRagDefinitions(taskRegistry, workflowRegistry, methodRegistry)
+
+    expect(() => {
+      registerRagDefinitions(taskRegistry, workflowRegistry, methodRegistry)
+    }).toThrow('already registered')
+  })
+})

--- a/agent-lab/backend/src/modules/rag/definitions.ts
+++ b/agent-lab/backend/src/modules/rag/definitions.ts
@@ -1,0 +1,56 @@
+import type {
+  MethodDefinition,
+  TaskDefinition,
+  WorkflowDefinition
+} from '../../core/contracts/definitions.js'
+
+export const ragTaskDefinitions: TaskDefinition[] = [
+  {
+    id: 'rag.qa',
+    name: 'RAG Question Answering',
+    type: 'rag',
+    successCriteria: ['grounded_answer', 'citation_precision']
+  }
+]
+
+export const ragWorkflowDefinitions: WorkflowDefinition[] = [
+  {
+    id: 'rag.retrieve-generate',
+    name: 'Retrieve and Generate',
+    steps: [
+      { stepId: 'retrieve', name: 'Retrieve relevant chunks' },
+      { stepId: 'generate', name: 'Generate grounded answer' }
+    ]
+  }
+]
+
+export const ragMethodDefinitions: MethodDefinition[] = [
+  {
+    id: 'rag.bm25.template',
+    name: 'BM25 Template Generator',
+    strategy: 'bm25',
+    implementation: 'rag.bm25'
+  }
+]
+
+type Registry<T> = {
+  register: (definition: T) => void
+}
+
+export const registerRagDefinitions = (
+  taskRegistry: Registry<TaskDefinition>,
+  workflowRegistry: Registry<WorkflowDefinition>,
+  methodRegistry: Registry<MethodDefinition>
+): void => {
+  for (const definition of ragTaskDefinitions) {
+    taskRegistry.register(definition)
+  }
+
+  for (const definition of ragWorkflowDefinitions) {
+    workflowRegistry.register(definition)
+  }
+
+  for (const definition of ragMethodDefinitions) {
+    methodRegistry.register(definition)
+  }
+}

--- a/agent-lab/backend/src/modules/rag/index.ts
+++ b/agent-lab/backend/src/modules/rag/index.ts
@@ -3,3 +3,9 @@ export { RagMetricsEvaluator } from './evaluators/rag-metrics-evaluator.js'
 export { RagMockRunner } from './runners/rag-mock-runner.js'
 export { RagBm25Runner } from './runners/rag-bm25-runner.js'
 export { RagArtifactSchemas } from './schemas.js'
+export {
+  ragTaskDefinitions,
+  ragWorkflowDefinitions,
+  ragMethodDefinitions,
+  registerRagDefinitions
+} from './definitions.js'


### PR DESCRIPTION
## Summary
- replace eval API local wiring with a runtime composition root and switch RAG execution from `rag.mock` to `rag.bm25`
- register RAG Task/Workflow/Method definitions and expose them via `GET /api/eval/definitions`
- add runtime/definition tests to ensure RAG run outputs artifacts/reports/scores and persists reproducibility provenance

## Test Plan
- [x] npm test -- --run src/modules/rag/definitions.test.ts src/api/eval/runtime.test.ts src/modules/rag/runners/rag-bm25-runner.e2e.test.ts src/core/engine/eval-engine.reporter.test.ts

Closes #6
