### PR TITLE
fix(backend): stabilize prisma storage test baseline

### DIFF
--- a/agent-lab/backend/README.md
+++ b/agent-lab/backend/README.md
@@ -142,8 +142,14 @@ backend/
 ### 运行测试
 
 ```bash
-# 运行所有测试
+# 运行所有测试（会自动准备 prisma/test.db）
 npm test
+
+# 运行存储层测试（先执行最小化迁移）
+npm run test:storage
+
+# 仅准备测试数据库（调试时可单独执行）
+npm run test:prepare-db
 
 # 运行测试并查看覆盖率
 npm run test:coverage

--- a/agent-lab/backend/README.md
+++ b/agent-lab/backend/README.md
@@ -158,6 +158,8 @@ npm run test:coverage
 npm test -- --watch
 ```
 
+`npm run test:prepare-db` 会删除并重建 `prisma/test.db`，再执行 `prisma/schema.prisma` 下全部迁移，保证 `score_records` 等测试表一致。
+
 ### 数据库操作
 
 ```bash

--- a/agent-lab/backend/package.json
+++ b/agent-lab/backend/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
-    "test:prepare-db": "tsx src/test/prepare-test-database.ts",
+    "test:prepare-db": "node --import tsx src/test/prepare-test-database.ts",
     "test:storage": "npm run test:prepare-db && vitest run src/core/engine/prisma-storage.test.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",

--- a/agent-lab/backend/package.json
+++ b/agent-lab/backend/package.json
@@ -10,6 +10,8 @@
     "start": "node dist/index.js",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
+    "test:prepare-db": "tsx src/test/prepare-test-database.ts",
+    "test:storage": "npm run test:prepare-db && vitest run src/core/engine/prisma-storage.test.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:studio": "prisma studio",

--- a/agent-lab/backend/src/test/global-setup.ts
+++ b/agent-lab/backend/src/test/global-setup.ts
@@ -1,0 +1,6 @@
+import { prepareTestDatabase, TEST_DATABASE_URL } from './prepare-test-database.js'
+
+export default async function globalSetup(): Promise<void> {
+  process.env.DATABASE_URL = TEST_DATABASE_URL
+  prepareTestDatabase({ quiet: true })
+}

--- a/agent-lab/backend/src/test/prepare-test-database.ts
+++ b/agent-lab/backend/src/test/prepare-test-database.ts
@@ -1,0 +1,42 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const currentDir = dirname(fileURLToPath(import.meta.url))
+const projectRoot = resolve(currentDir, '..', '..')
+const testDatabasePath = resolve(projectRoot, 'prisma', 'test.db')
+
+export const TEST_DATABASE_URL = 'file:./test.db'
+
+export function prepareTestDatabase(options?: { quiet?: boolean }): void {
+  if (existsSync(testDatabasePath)) {
+    rmSync(testDatabasePath)
+  }
+
+  // Ensure the SQLite file exists before running migrate on external volumes.
+  writeFileSync(testDatabasePath, '', { encoding: 'utf8' })
+
+  const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx'
+
+  execFileSync(
+    npxCommand,
+    ['prisma', 'migrate', 'deploy', '--schema', 'prisma/schema.prisma'],
+    {
+      cwd: projectRoot,
+      env: {
+        ...process.env,
+        DATABASE_URL: TEST_DATABASE_URL,
+      },
+      stdio: options?.quiet ? 'pipe' : 'inherit',
+    },
+  )
+}
+
+const invokedAsScript = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false
+
+if (invokedAsScript) {
+  prepareTestDatabase()
+}

--- a/agent-lab/backend/vitest.config.ts
+++ b/agent-lab/backend/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    globalSetup: ['./src/test/global-setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
What: cherry-pick the storage DB baseline prep from branch codex/issue-g-prisma-storage-baseline; add vitest global setup and test:storage/test:prepare-db workflow for Prisma test DB; switch test:prepare-db to node --import tsx to avoid tsx IPC EPERM in sandboxed environments; document storage test DB init behavior in backend README. Verify: cd agent-lab/backend && npm run test:storage; cd agent-lab/backend && npx vitest run. Refs #15.