### PR TITLE
ci(frontend): add layered quality gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,8 @@
 
 - [ ] `cd agent-lab/backend && npm run gate:run-priority`
 - [ ] `cd agent-lab/backend && npm run gate:strict-green` (required for `Strict-Green`)
-- [ ] `cd agent-lab/frontend && npm run build`
-- [ ] `cd agent-lab/frontend && npm run lint` (required for `Strict-Green`)
+- [ ] `cd agent-lab/frontend && npm run gate:run-priority`
+- [ ] `cd agent-lab/frontend && npm run gate:strict-green` (required for `Strict-Green`)
 
 ## Debt / Follow-up (Required)
 

--- a/.github/workflows/frontend-quality-gates.yml
+++ b/.github/workflows/frontend-quality-gates.yml
@@ -1,0 +1,80 @@
+name: Frontend Quality Gates
+
+on:
+  pull_request:
+    paths:
+      - 'agent-lab/frontend/**'
+      - '.github/workflows/frontend-quality-gates.yml'
+      - 'docs/process/quality-gates.md'
+      - '.github/pull_request_template.md'
+  push:
+    branches:
+      - main
+      - codex/integration-fix-issues-5-9
+    paths:
+      - 'agent-lab/frontend/**'
+      - '.github/workflows/frontend-quality-gates.yml'
+      - 'docs/process/quality-gates.md'
+  workflow_dispatch:
+    inputs:
+      gate:
+        description: Quality gate level
+        type: choice
+        required: true
+        default: run-priority
+        options:
+          - run-priority
+          - strict-green
+
+permissions:
+  contents: read
+
+jobs:
+  frontend-run-priority:
+    name: Frontend Run-Priority
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.gate == 'run-priority' || github.event.inputs.gate == 'strict-green'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: agent-lab/frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: agent-lab/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run frontend run-priority gate
+        run: npm run gate:run-priority
+
+  frontend-strict-green:
+    name: Frontend Strict-Green
+    needs: frontend-run-priority
+    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.gate == 'strict-green') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: agent-lab/frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: agent-lab/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run frontend strict-green gate
+        run: npm run gate:strict-green

--- a/agent-lab/frontend/package.json
+++ b/agent-lab/frontend/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "gate:run-priority": "npm run build",
+    "gate:strict-green": "npm run gate:run-priority && npm run lint"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/docs/process/quality-gates.md
+++ b/docs/process/quality-gates.md
@@ -24,7 +24,8 @@
 
 ## CI Mapping
 
-- Workflow: `.github/workflows/backend-quality-gates.yml`
+- Backend workflow: `.github/workflows/backend-quality-gates.yml`
+- Frontend workflow: `.github/workflows/frontend-quality-gates.yml`
 - Pull requests run `Run-Priority` automatically.
 - `Strict-Green` can run via manual workflow dispatch (`gate=strict-green`) and on push to `main`.
 


### PR DESCRIPTION
Completes the frontend side of #17 after checking duplicate risk (no existing frontend gate PR/workflow in repo).

What changed:
- add frontend gate scripts (gate:run-priority, gate:strict-green)
- add .github/workflows/frontend-quality-gates.yml with PR run-priority + dispatch/main strict-green behavior
- align PR template verification commands to gate scripts
- update quality gate doc CI mapping for backend+frontend workflows

Verification:
- cd agent-lab/frontend && npm run gate:run-priority: PASS
- cd agent-lab/frontend && npm run gate:strict-green: FAIL (expected currently, blocked by existing lint debt tracked in #14: 10 errors / 6 warnings)

Refs #17 #14