### PR TITLE
docs: integrate INT-006 runtime smoke guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ npm install
 
 # Configure environment variables
 cp .env.example .env
-# Edit .env and set ENCRYPTION_KEY (32 characters)
+# Edit .env and set ENCRYPTION_KEY + ENCRYPTION_SALT
+# ENCRYPTION_KEY: >= 32 characters
+# ENCRYPTION_SALT: >= 32 hex characters (>= 16 bytes)
 
 # Initialize database
 npm run prisma:generate
@@ -182,14 +184,17 @@ npm run dev
 **4. Verify Installation**
 
 ```bash
-# Test backend health check
+# Smoke check 1: health
 curl http://localhost:3001/health
-# Should return: {"status":"ok","timestamp":"..."}
 
-# View built-in Agents
-curl http://localhost:3001/api/agents
-# Should return 3 built-in Agents
+# Smoke check 2: registered runners
+curl http://localhost:3001/api/eval/runners
+
+# Smoke check 3: registry definitions
+curl http://localhost:3001/api/eval/definitions
 ```
+
+For sandbox/CI environments that cannot listen on localhost ports, use the fallback verification steps in [`agent-lab/backend/docs/RUNTIME_SMOKE_GUIDE.md`](./agent-lab/backend/docs/RUNTIME_SMOKE_GUIDE.md).
 
 ### 💡 User Guide
 
@@ -539,7 +544,9 @@ npm install
 
 # 配置环境变量
 cp .env.example .env
-# 编辑 .env，设置 ENCRYPTION_KEY（32位字符）
+# 编辑 .env，设置 ENCRYPTION_KEY + ENCRYPTION_SALT
+# ENCRYPTION_KEY: 至少 32 位字符
+# ENCRYPTION_SALT: 至少 32 位十六进制字符（>= 16 bytes）
 
 # 初始化数据库
 npm run prisma:generate
@@ -567,14 +574,17 @@ npm run dev
 **4. 验证安装**
 
 ```bash
-# 测试后端健康检查
+# Smoke 检查 1：健康检查
 curl http://localhost:3001/health
-# 应返回: {"status":"ok","timestamp":"..."}
 
-# 查看内置 Agent
-curl http://localhost:3001/api/agents
-# 应返回 3 个内置 Agent
+# Smoke 检查 2：注册 Runner
+curl http://localhost:3001/api/eval/runners
+
+# Smoke 检查 3：注册定义
+curl http://localhost:3001/api/eval/definitions
 ```
+
+若在 sandbox/受限 CI 中无法监听本地端口，请改用替代验证流程：[`agent-lab/backend/docs/RUNTIME_SMOKE_GUIDE.md`](./agent-lab/backend/docs/RUNTIME_SMOKE_GUIDE.md)。
 
 ### 💡 使用指南
 

--- a/agent-lab/backend/docs/RUNTIME_SMOKE_GUIDE.md
+++ b/agent-lab/backend/docs/RUNTIME_SMOKE_GUIDE.md
@@ -1,0 +1,95 @@
+# 运行时配置与 Smoke 指南（INT-006）
+
+本文档用于统一后端启动说明、标准 smoke 命令，以及受限环境下的替代验证流程。
+
+## 1. 必填环境变量
+
+复制环境变量模板：
+
+```bash
+cp .env.example .env
+```
+
+必须配置以下变量（缺一不可）：
+
+```env
+ENCRYPTION_KEY=your_32_character_encryption_key_here
+ENCRYPTION_SALT=your_32_hex_character_salt_here
+```
+
+约束规则：
+
+- `ENCRYPTION_KEY`：长度 >= 32 字符
+- `ENCRYPTION_SALT`：十六进制字符串，长度 >= 32（至少 16 bytes）
+
+快速生成示例：
+
+```bash
+node -e "const crypto=require('crypto'); console.log('ENCRYPTION_KEY=' + crypto.randomBytes(24).toString('hex')); console.log('ENCRYPTION_SALT=' + crypto.randomBytes(16).toString('hex'));"
+```
+
+## 2. 标准启动步骤
+
+```bash
+cd agent-lab/backend
+npm install
+npm run prisma:generate
+npm run prisma:migrate
+npm run prisma:seed
+npm run dev
+```
+
+默认服务地址：`http://localhost:3001`
+
+## 3. 标准 Smoke 命令（验收口径）
+
+后端启动后，执行以下 3 条命令：
+
+```bash
+curl http://localhost:3001/health
+curl http://localhost:3001/api/eval/runners
+curl http://localhost:3001/api/eval/definitions
+```
+
+期望结果：
+
+- `/health` 返回 `{"status":"ok",...}`
+- `/api/eval/runners` 返回 `success: true` 且 `data` 为非空数组
+- `/api/eval/definitions` 返回 `success: true` 且 `data` 包含定义数据
+
+## 4. 受限环境替代验证（无法监听 localhost:3001）
+
+如果运行环境无法开放监听端口（常见于沙箱/受限 CI），可改用以下替代验证：
+
+```bash
+cd agent-lab/backend
+
+# 1) 校验 ENCRYPTION_* 格式
+ENCRYPTION_KEY="${ENCRYPTION_KEY:-12345678901234567890123456789012}" \
+ENCRYPTION_SALT="${ENCRYPTION_SALT:-0123456789abcdef0123456789abcdef}" \
+node -e "const key=process.env.ENCRYPTION_KEY||''; const salt=process.env.ENCRYPTION_SALT||''; if(key.length<32) throw new Error('ENCRYPTION_KEY must be at least 32 chars'); if(!/^[0-9a-fA-F]{32,}$/.test(salt)) throw new Error('ENCRYPTION_SALT must be hex and >=32 chars'); console.log('ENCRYPTION_* format check passed');"
+
+# 2) 静态检查关键路由声明
+rg "app.get\\('/health'" src/index.ts
+rg "router.get\\('/runners'" src/api/eval/index.ts
+rg "router.get\\('/definitions'" src/api/eval/index.ts
+
+# 3) 编译检查（确认 TS 构建通过）
+npm run build
+```
+
+说明：替代验证不依赖端口监听，但可覆盖配置合法性、关键路由存在性和编译可用性三项风险。
+
+## 5. 常见失败与排查
+
+- `ENCRYPTION_KEY environment variable must be set...`：密钥长度不足或为空
+- `ENCRYPTION_SALT environment variable must be set...`：salt 非 hex 或长度不足
+- `curl` 连接失败：后端未启动、端口冲突或受限环境禁止监听
+- `/api/eval/definitions` 返回 404：当前分支未包含 definitions 路由，需要同步集成分支
+
+## 6. Merge 前运行记录模板
+
+为避免交接时缺少验收证据，建议在 PR merge 汇总中使用统一模板：
+
+- 模板路径：[`docs/templates/MERGE_SUMMARY_TEMPLATE.md`](../../../docs/templates/MERGE_SUMMARY_TEMPLATE.md)
+- 模板内已固定引用本指南：`agent-lab/backend/docs/RUNTIME_SMOKE_GUIDE.md`

--- a/agent-lab/backend/docs/api/API.md
+++ b/agent-lab/backend/docs/api/API.md
@@ -595,7 +595,11 @@ NODE_ENV=development
 PORT=3001
 DATABASE_URL="file:./dev.db"
 ENCRYPTION_KEY=your_32_character_key_here
+ENCRYPTION_SALT=your_32_hex_character_salt_here
 ```
+
+- `ENCRYPTION_KEY`：至少 32 字符
+- `ENCRYPTION_SALT`：至少 32 位十六进制字符（>= 16 bytes）
 
 ### 本地运行
 
@@ -614,7 +618,14 @@ npm run prisma:seed
 
 # 启动开发服务器
 npm run dev
+
+# smoke 验证
+curl http://localhost:3001/health
+curl http://localhost:3001/api/eval/runners
+curl http://localhost:3001/api/eval/definitions
 ```
+
+受限环境替代验证请参考：[`../RUNTIME_SMOKE_GUIDE.md`](../RUNTIME_SMOKE_GUIDE.md)
 
 ### 运行测试
 

--- a/docs/templates/MERGE_SUMMARY_TEMPLATE.md
+++ b/docs/templates/MERGE_SUMMARY_TEMPLATE.md
@@ -1,0 +1,55 @@
+# Merge 汇总模板（运行时配置与 Smoke）
+
+> 用途：用于 issue5-9 链路合并前的运行记录留档，确保配置、smoke 与受限环境验证证据完整。
+
+## 1) 基本信息
+
+- Issue: `#`
+- PR: `#`
+- Branch: ``
+- 执行日期: `YYYY-MM-DD`
+- 执行人: ``
+
+## 2) 必填配置检查
+
+- [ ] `ENCRYPTION_KEY` 已配置且长度 >= 32
+- [ ] `ENCRYPTION_SALT` 已配置且为 hex，长度 >= 32
+
+示例（脱敏后）：
+
+```env
+ENCRYPTION_KEY=********************************
+ENCRYPTION_SALT=********************************
+```
+
+## 3) 标准 Smoke 结果
+
+执行命令：
+
+```bash
+curl http://localhost:3001/health
+curl http://localhost:3001/api/eval/runners
+curl http://localhost:3001/api/eval/definitions
+```
+
+结果记录：
+
+- `/health`: `status=ok` / `timestamp=...`
+- `/api/eval/runners`: `success=true` / `data.length=...`
+- `/api/eval/definitions`: `success=true` / `definitions=...`
+
+## 4) 受限环境替代验证（如适用）
+
+- [ ] `ENCRYPTION_*` 格式检查通过
+- [ ] 路由声明静态检查通过
+- [ ] `npm run build` 通过
+
+附：关键输出片段（粘贴日志）
+
+```text
+<paste logs here>
+```
+
+## 5) 文档引用
+
+- 运行时配置与 Smoke 指南：[`agent-lab/backend/docs/RUNTIME_SMOKE_GUIDE.md`](../../agent-lab/backend/docs/RUNTIME_SMOKE_GUIDE.md)


### PR DESCRIPTION
Integrates the already-prepared INT-006 docs commit into the integration branch so issue #23 can be closed in the same merge train.

Source commit:
- c272511 (originally on codex/int-006-runtime-smoke-guide)

Included files:
- README runtime config + smoke references
- backend README env constraints + smoke + fallback verification
- agent-lab/backend/docs/RUNTIME_SMOKE_GUIDE.md
- docs/templates/MERGE_SUMMARY_TEMPLATE.md
- backend API docs update

Verification run in this branch:
- ENCRYPTION_* format check command: PASS
- route declaration grep for /health /runners /definitions: PASS
- cd agent-lab/backend && npm run build: PASS

Refs #23