### PR TITLE
build(frontend): default to turbopack with webpack fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,20 @@ npm run dev
 # 🎨 Frontend running at http://localhost:3000
 ```
 
+**Build Mode Guide (Frontend)**
+
+```bash
+cd frontend
+
+# Default build path (Turbopack)
+npm run build
+
+# Fallback for restricted/sandboxed environments
+npm run build:webpack
+```
+
+Use `npm run build:webpack` when Turbopack fails with environment restrictions (for example `Operation not permitted (os error 1)` while binding resources).
+
 **4. Verify Installation**
 
 ```bash
@@ -570,6 +584,20 @@ npm install
 npm run dev
 # 🎨 前端运行在 http://localhost:3000
 ```
+
+**前端构建模式说明**
+
+```bash
+cd frontend
+
+# 默认构建路径（Turbopack）
+npm run build
+
+# 受限 / 沙箱环境回退路径
+npm run build:webpack
+```
+
+如果 Turbopack 在受限环境报错（例如 `Operation not permitted (os error 1)`），请切换到 `npm run build:webpack`。
 
 **4. 验证安装**
 

--- a/agent-lab/frontend/package.json
+++ b/agent-lab/frontend/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build --webpack",
+    "build": "next build",
+    "build:webpack": "next build --webpack",
     "start": "next start",
     "lint": "eslint",
     "gate:run-priority": "npm run build",


### PR DESCRIPTION
Integrates issue #16 work into the active integration branch.

What changed:
- restore frontend default build to Turbopack (`npm run build`)
- add explicit webpack fallback (`npm run build:webpack`)
- document build mode selection in README (EN + ZH)

Verification evidence:
- `cd agent-lab/frontend && npm run build` -> reproduces known restricted-env Turbopack bind error (`Operation not permitted (os error 1)`) in this sandbox
- `cd agent-lab/frontend && npm run build:webpack` -> PASS
- `next/font/google` usage check -> no matches in `agent-lab/frontend/src` (no external font fetch dependency)

This matches the strategy for #16: keep Turbopack as default path for normal environments and keep webpack fallback for restricted/sandboxed environments.

Refs #16